### PR TITLE
Standardize page title handling

### DIFF
--- a/18D/404.php
+++ b/18D/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found | 18Date.net';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/18D/cookie-policy.php
+++ b/18D/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://18date.net/cookie-policy';
 $pageTitle = 'Cookiebeleid | 18Date.net';
 include $base . '/includes/header.php';

--- a/18D/datingtips.php
+++ b/18D/datingtips.php
@@ -1,6 +1,5 @@
 <?php 
 $base = __DIR__;
-define("TITLE", "Datingtips");
 
 $canonical = 'https://18date.net/datingtips';
 $pageTitle = 'Datingtips | 18Date.net';

--- a/18D/includes/header.php
+++ b/18D/includes/header.php
@@ -22,7 +22,10 @@
     'tips_title_prefix' => 'Sexdatingtips',
   ];
 
-  list($canonical, $pageTitle, $ogImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  list($generatedCanonical, $generatedPageTitle, $generatedOgImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  $canonical = isset($canonical) ? $canonical : $generatedCanonical;
+  $pageTitle = isset($pageTitle) ? $pageTitle : $generatedPageTitle;
+  $ogImage   = isset($ogImage) ? $ogImage : $generatedOgImage;
 
 ?>
 

--- a/18D/index.php
+++ b/18D/index.php
@@ -1,6 +1,6 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Home");
+$pageTitle = '18+ Sexdating | 18Date.net';
 include $base . '/includes/header.php';
 ?>
 

--- a/18D/land.php
+++ b/18D/land.php
@@ -74,7 +74,6 @@ $landInfo = ${$info['landVar']};
 
 $canonical = $info['canonical'];
 $pageTitle = $info['pageTitle'];
-define('TITLE', $info['title']);
 $metaDescription = $landInfo['meta'];
 
 include $base . '/includes/header.php';

--- a/18D/partnerlinks.php
+++ b/18D/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://18date.net/partnerlinks';
 $pageTitle = 'Partnerlinks | 18Date.net';
 include $base . '/includes/header.php';

--- a/18D/privacy.php
+++ b/18D/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacybeleid');
 $canonical = 'https://18date.net/privacy';
 $pageTitle = 'Privacybeleid | 18Date.net';
 include $base . '/includes/header.php';

--- a/18D/profile.php
+++ b/18D/profile.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define("TITLE", "Daten");
 include $base . '/includes/header.php';
 ?>
 <!-- Page Content -->

--- a/18D/province.php
+++ b/18D/province.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Daten in');
 require_once $base . '/includes/utils.php';
 
 $country = isset($_GET['country']) ? strtolower($_GET['country']) : '';
@@ -43,6 +42,7 @@ if (!$province) {
 }
 
 $metaDescription = $province['meta'];
+$pageTitle = $province['title'] . ' | 18Date.net';
 include $base . '/includes/header.php';
 ?>
 

--- a/S55/404.php
+++ b/S55/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found | sex55.net';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/S55/cookie-policy.php
+++ b/S55/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://sex55.net/cookie-policy';
 $pageTitle = 'Cookiebeleid | sex55.net';
 include $base . '/includes/header.php';

--- a/S55/datingtips.php
+++ b/S55/datingtips.php
@@ -1,6 +1,5 @@
 <?php 
 $base = __DIR__;
-define("TITLE", "Datingtips");
 
 $canonical = 'https://sex55.net/datingtips';
 $pageTitle = 'Datingtips | sex55.net';

--- a/S55/includes/header.php
+++ b/S55/includes/header.php
@@ -22,7 +22,10 @@
     'tips_title_prefix' => 'Datingtips',
   ];
 
-  list($canonical, $pageTitle, $ogImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  list($generatedCanonical, $generatedPageTitle, $generatedOgImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  $canonical = isset($canonical) ? $canonical : $generatedCanonical;
+  $pageTitle = isset($pageTitle) ? $pageTitle : $generatedPageTitle;
+  $ogImage   = isset($ogImage) ? $ogImage : $generatedOgImage;
 
 ?>
 

--- a/S55/index.php
+++ b/S55/index.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "Home");
-  include $base . '/includes/header.php';
+$pageTitle = '55+ Sexdating | sex55.net';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/S55/land.php
+++ b/S55/land.php
@@ -74,7 +74,6 @@ $landInfo = ${$info['landVar']};
 
 $canonical = $info['canonical'];
 $pageTitle = $info['pageTitle'];
-define('TITLE', $info['title']);
 $metaDescription = $landInfo['meta'];
 
 include $base . '/includes/header.php';

--- a/S55/partnerlinks.php
+++ b/S55/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://sex55.net/partnerlinks';
 $pageTitle = 'Partnerlinks | sex55.net';
 include $base . '/includes/header.php';

--- a/S55/privacy.php
+++ b/S55/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacybeleid');
 $canonical = 'https://sex55.net/privacy';
 $pageTitle = 'Privacybeleid | sex55.net';
 include $base . '/includes/header.php';

--- a/S55/profile-be.php
+++ b/S55/profile-be.php
@@ -1,6 +1,5 @@
 <?php
-	define("TITLE", "Daten");
-	include('includes/header.php');
+include('includes/header.php');
 ?>
 <!-- Page Content -->
 <div class="container" id="profiel" v-cloak>

--- a/S55/profile-nl.php
+++ b/S55/profile-nl.php
@@ -1,6 +1,5 @@
 <?php
-  define("TITLE", "Daten");
-  include('includes/header.php');
+include('includes/header.php');
 ?>
 <!-- Page Content -->
 <div class="container" id="profiel" v-cloak>

--- a/S55/profile.php
+++ b/S55/profile.php
@@ -1,7 +1,6 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "Daten");
-  include $base . '/includes/header.php';
+include $base . '/includes/header.php';
 ?>
 <!-- Page Content -->
     <div class="container" id="profiel">

--- a/S55/province.php
+++ b/S55/province.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Daten in');
 require_once $base . '/includes/utils.php';
 
 $country = isset($_GET['country']) ? strtolower($_GET['country']) : '';
@@ -43,6 +42,7 @@ if (!$province) {
 }
 
 $metaDescription = $province['meta'];
+$pageTitle = $province['title'] . ' | sex55.net';
 include $base . '/includes/header.php';
 ?>
 

--- a/SD/404.php
+++ b/SD/404.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "404 | Page not found");
-	include $base . '/includes/header.php';
+$pageTitle = '404 | Page not found | shemaledaten.net';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/SD/cookie-policy.php
+++ b/SD/cookie-policy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Cookiebeleid');
 $canonical = 'https://shemaledaten.net/cookie-policy';
 $pageTitle = 'Cookiebeleid | shemaledaten.net';
 include $base . '/includes/header.php';

--- a/SD/datingtips.php
+++ b/SD/datingtips.php
@@ -1,6 +1,5 @@
 <?php 
 $base = __DIR__;
-define("TITLE", "Datingtips");
 
 $canonical = 'https://shemaledaten.net/datingtips';
 $pageTitle = 'Datingtips | shemaledaten.net';

--- a/SD/includes/header.php
+++ b/SD/includes/header.php
@@ -22,7 +22,10 @@
     'tips_title_prefix' => 'Datingtips',
   ];
 
-  list($canonical, $pageTitle, $ogImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  list($generatedCanonical, $generatedPageTitle, $generatedOgImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  $canonical = isset($canonical) ? $canonical : $generatedCanonical;
+  $pageTitle = isset($pageTitle) ? $pageTitle : $generatedPageTitle;
+  $ogImage   = isset($ogImage) ? $ogImage : $generatedOgImage;
 
 ?>
 

--- a/SD/index.php
+++ b/SD/index.php
@@ -1,7 +1,7 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "Home");
-  include $base . '/includes/header.php';
+$pageTitle = 'Shemale Sexdating | shemaledaten.net';
+include $base . '/includes/header.php';
 ?>
 
 <div class="container">

--- a/SD/land.php
+++ b/SD/land.php
@@ -74,7 +74,6 @@ $landInfo = ${$info['landVar']};
 
 $canonical = $info['canonical'];
 $pageTitle = $info['pageTitle'];
-define('TITLE', $info['title']);
 $metaDescription = $landInfo['meta'];
 
 include $base . '/includes/header.php';

--- a/SD/partnerlinks.php
+++ b/SD/partnerlinks.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Partnerlinks');
 $canonical = 'https://shemaledaten.net/partnerlinks';
 $pageTitle = 'Partnerlinks | shemaledaten.net';
 include $base . '/includes/header.php';

--- a/SD/privacy.php
+++ b/SD/privacy.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Privacybeleid');
 $canonical = 'https://shemaledaten.net/privacy';
 $pageTitle = 'Privacybeleid | shemaledaten.net';
 include $base . '/includes/header.php';

--- a/SD/profile.php
+++ b/SD/profile.php
@@ -1,7 +1,6 @@
 <?php
 $base = __DIR__;
-	define("TITLE", "Daten");
-  include $base . '/includes/header.php';
+include $base . '/includes/header.php';
 ?>
 <!-- Page Content -->
     <div class="container" id="profiel">

--- a/SD/province.php
+++ b/SD/province.php
@@ -1,6 +1,5 @@
 <?php
 $base = __DIR__;
-define('TITLE', 'Shemale');
 require_once $base . '/includes/utils.php';
 
 $country = isset($_GET['country']) ? strtolower($_GET['country']) : '';
@@ -43,6 +42,7 @@ if (!$province) {
 }
 
 $metaDescription = $province['meta'];
+$pageTitle = $province['title'] . ' | shemaledaten.net';
 include $base . '/includes/header.php';
 ?>
 


### PR DESCRIPTION
## Summary
- honor `$pageTitle` from page when building meta tags
- clean up page header setup
- drop unused `TITLE` constants
- use `$pageTitle` for explicit titles on landing and error pages

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665ac240cc83248ba55da87c420f95