### PR TITLE
Fix CSS vendor paths

### DIFF
--- a/18D/includes/header.php
+++ b/18D/includes/header.php
@@ -66,7 +66,7 @@
 ?>
 
 <!-- Bootstrap core CSS -->
-<link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+<link href="css/vendor/bootstrap.min.css" rel="stylesheet">
 
 <!-- Custom styles for this template -->
 <link href="css/style.css" rel="stylesheet">

--- a/S55/includes/header.php
+++ b/S55/includes/header.php
@@ -66,7 +66,7 @@
 ?>
 
 <!-- Bootstrap core CSS -->
-<link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+<link href="css/vendor/bootstrap.min.css" rel="stylesheet">
 
 <!-- Custom styles for this template -->
 <link href="css/style.css" rel="stylesheet">

--- a/SD/includes/header.php
+++ b/SD/includes/header.php
@@ -66,7 +66,7 @@
 ?>
 
 <!-- Bootstrap core CSS -->
-<link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+<link href="css/vendor/bootstrap.min.css" rel="stylesheet">
 
 <!-- Custom styles for this template -->
 <link href="css/style.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- update bootstrap CSS link in all header files to match new css/vendor structure

## Testing
- `npm test` in `18D`
- `npm test` in `S55`
- `npm test` in `SD` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68666093bcf083249ed07614c43a10ee