### PR TITLE
Add sitemap generation logs

### DIFF
--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -149,3 +149,4 @@ foreach (['partnerlinks', 'privacy', 'cookie-policy'] as $page) {
 }
 
 merge_into_sitemap($urls, __DIR__ . '/sitemap.xml', $baseUrl);
+echo sprintf("Sitemap updated with %d URLs\n", count($urls));

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -149,3 +149,4 @@ foreach (['partnerlinks', 'privacy', 'cookie-policy'] as $page) {
 }
 
 merge_into_sitemap($urls, __DIR__ . '/sitemap.xml', $baseUrl);
+echo sprintf("Sitemap updated with %d URLs\n", count($urls));

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -149,3 +149,4 @@ foreach (['partnerlinks', 'privacy', 'cookie-policy'] as $page) {
 }
 
 merge_into_sitemap($urls, __DIR__ . '/sitemap.xml', $baseUrl);
+echo sprintf("Sitemap updated with %d URLs\n", count($urls));


### PR DESCRIPTION
## Summary
- confirm sitemap generation in cron logs by printing a status message

## Testing
- `php -l 18D/generate_sitemap.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ead7b2ce083249cf302eb660c673c