### PR TITLE
Fix profile URLs in sitemap generator

### DIFF
--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -1,153 +1,73 @@
 <?php
-// Simple sitemap generator for 18date.net
-
+require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 require_once __DIR__ . '/includes/config.php';
+require __DIR__ . '/includes/arr_prov_nl.php';
+require __DIR__ . '/includes/arr_prov_be.php';
+require __DIR__ . '/includes/arr_prov_uk.php';
+require __DIR__ . '/includes/arr_prov_de.php';
+require __DIR__ . '/includes/arr_prov_at.php';
+require __DIR__ . '/includes/arr_prov_ch.php';
+require __DIR__ . '/includes/array_tips.php';
 
 $baseUrl = $BASE_URL;
 
-// Determine the prefix used for profile pages based on domain
 $profilePrefix = 'date-';
 if (strpos($baseUrl, 'shemaledaten.net') !== false) {
     $profilePrefix = 'shemale-';
 }
 
-/**
- * Fetch profile slugs from the remote API.
- * Expects JSON {"slugs": ["foo", "bar", ...]}
- *
- * @param string $country Two letter code
- * @return array
- */
-function fetch_profile_slugs($country)
-{
-    $endpoint = rtrim(api_base($country), '/') . '/profile/slugs';
-    $json = @file_get_contents($endpoint);
-    if ($json === false) {
-        return [];
-    }
-    $data = json_decode($json, true);
-    if (!$data || !isset($data['slugs']) || !is_array($data['slugs'])) {
-        return [];
-    }
-    return $data['slugs'];
+$urls = [];
+$static = ['', 'datingtips', 'partnerlinks', 'privacy', 'cookie-policy'];
+foreach ($static as $page) {
+    $urls[] = rtrim($baseUrl, '/') . '/' . ltrim($page, '/');
 }
 
-function add_url(array &$urls, $loc)
-{
-    $urls[] = [
-        'loc' => $loc,
-        'lastmod' => gmdate('c'),
-    ];
-}
+$countryMap = [
+    'nl' => ['slug' => 'sexdate-nederland',       'prov' => $nl],
+    'be' => ['slug' => 'sexdate-belgie',          'prov' => $be],
+    'uk' => ['slug' => 'sexdate-verenigd-koninkrijk', 'prov' => $uk],
+    'de' => ['slug' => 'sexdate-duitsland',       'prov' => $de],
+    'at' => ['slug' => 'sexdate-oostenrijk',      'prov' => $at],
+    'ch' => ['slug' => 'sexdate-zwitserland',     'prov' => $ch],
+];
 
-/**
- * Merge generated URLs into the existing sitemap without duplicating entries.
- *
- * @param array  $urls       Array with loc and lastmod keys
- * @param string $sitemap    Path to sitemap.xml
- */
-function merge_into_sitemap(array $urls, $sitemap, $baseUrl)
-{
-    $ordered = [];
-    $seen = [];
-
-    if (file_exists($sitemap)) {
-        $existingDom = new DOMDocument();
-        $existingDom->load($sitemap);
-        foreach ($existingDom->getElementsByTagName('url') as $urlNode) {
-            $locNode = $urlNode->getElementsByTagName('loc')->item(0);
-            if (!$locNode) {
-                continue;
-            }
-            $loc = trim($locNode->textContent);
-            if (isset($seen[$loc])) {
-                continue;
-            }
-            $lastmodNode = $urlNode->getElementsByTagName('lastmod')->item(0);
-            $ordered[] = [
-                'loc' => $loc,
-                'lastmod' => $lastmodNode ? $lastmodNode->textContent : gmdate('c'),
-            ];
-            $seen[$loc] = true;
+$profileUrls = [];
+foreach ($countryMap as $code => $info) {
+    $urls[] = $baseUrl . '/' . $info['slug'];
+    foreach ($info['prov'] as $slug => $prov) {
+        $provSlug = 'sexdate-' . $slug;
+        if (($code === 'nl' || $code === 'be') && $slug === 'limburg') {
+            $provSlug = 'sexdate-limburg-' . $code;
         }
-    }
+        $urls[] = $baseUrl . '/' . $provSlug;
 
-    foreach ($urls as $u) {
-        $locVal = rtrim($baseUrl, '/') . '/' . ltrim($u['loc'], '/');
-        if (isset($seen[$locVal])) {
+        $endpoint = rtrim(api_base($code), '/') . '/profile/province/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) {
             continue;
         }
-        $ordered[] = [
-            'loc' => $locVal,
-            'lastmod' => $u['lastmod'],
-        ];
-        $seen[$locVal] = true;
-    }
-
-    $dom = new DOMDocument('1.0', 'UTF-8');
-    $dom->formatOutput = true;
-    $urlset = $dom->createElement('urlset');
-    $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-    $dom->appendChild($urlset);
-
-    foreach ($ordered as $entry) {
-        $url = $dom->createElement('url');
-        $url->appendChild($dom->createElement('loc', $entry['loc']));
-        $url->appendChild($dom->createElement('lastmod', $entry['lastmod']));
-        $urlset->appendChild($url);
-    }
-
-    $dom->save($sitemap);
-}
-
-$urls = [];
-
-add_url($urls, '');
-
-$countries = [
-    'nl' => ['file' => 'includes/arr_prov_nl.php', 'var' => 'nl', 'slug' => 'sexdate-nederland'],
-    'be' => ['file' => 'includes/arr_prov_be.php', 'var' => 'be', 'slug' => 'sexdate-belgie'],
-    'uk' => ['file' => 'includes/arr_prov_uk.php', 'var' => 'uk', 'slug' => 'sexdate-verenigd-koninkrijk'],
-    'de' => ['file' => 'includes/arr_prov_de.php', 'var' => 'de', 'slug' => 'sexdate-duitsland'],
-    'at' => ['file' => 'includes/arr_prov_at.php', 'var' => 'at', 'slug' => 'sexdate-oostenrijk'],
-    'ch' => ['file' => 'includes/arr_prov_ch.php', 'var' => 'ch', 'slug' => 'sexdate-zwitserland'],
-];
-
-foreach ($countries as $country => $info) {
-    add_url($urls, $info['slug']);
-    require __DIR__ . '/' . $info['file'];
-    $provArray = ${$info['var']};
-    foreach ($provArray as $slugKey => $item) {
-        $slug = 'sexdate-' . $slugKey;
-        if (($country === 'nl' || $country === 'be') && $slugKey === 'limburg') {
-            $slug = 'sexdate-limburg-' . $country;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles']) || !is_array($data['profiles'])) {
+            continue;
         }
-        add_url($urls, $slug);
+        foreach ($data['profiles'] as $p) {
+            if (empty($p['id']) || empty($p['name'])) {
+                continue;
+            }
+            $slugified = slugify($p['name']);
+            $profileUrls[$p['id']] = $baseUrl . '/' . $profilePrefix . $slugified . '?id=' . $p['id'];
+        }
     }
-
-    foreach (fetch_profile_slugs($country) as $profileSlug) {
-        add_url($urls, $profilePrefix . $profileSlug);
-    }
 }
 
-// Dating tips
-$datingtips = [
-    'datingtips',
-    'datingtips-nederland',
-    'datingtips-belgie',
-    'datingtips-verenigd-koninkrijk',
-    'datingtips-duitsland',
-    'datingtips-oostenrijk',
-    'datingtips-zwitserland',
-];
-foreach ($datingtips as $tip) {
-    add_url($urls, $tip);
+foreach (array_keys($datingtips) as $tip) {
+    $urls[] = $baseUrl . '/datingtips-' . $tip;
 }
 
-// Static pages
-foreach (['partnerlinks', 'privacy', 'cookie-policy'] as $page) {
-    add_url($urls, $page);
+foreach ($profileUrls as $url) {
+    $urls[] = $url;
 }
 
-merge_into_sitemap($urls, __DIR__ . '/sitemap.xml', $baseUrl);
-echo sprintf("Sitemap updated with %d URLs\n", count($urls));
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/18D/includes/sitemap.php
+++ b/18D/includes/sitemap.php
@@ -1,0 +1,50 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+
+    $doc = new DOMDocument('1.0', 'UTF-8');
+    $doc->preserveWhiteSpace = false;
+    $doc->formatOutput = true;
+
+    if (file_exists($sitemapPath)) {
+        @$doc->load($sitemapPath);
+        if (!$doc->documentElement) {
+            $doc->loadXML('<urlset xmlns="' . $namespace . '"/>');
+        }
+    } else {
+        $doc->loadXML('<urlset xmlns="' . $namespace . '"/>');
+    }
+
+    $xpath = new DOMXPath($doc);
+    $xpath->registerNamespace('sm', $namespace);
+
+    $existing = [];
+    foreach ($xpath->query('//sm:url') as $node) {
+        $locNode = $xpath->query('sm:loc', $node)->item(0);
+        if ($locNode) {
+            $loc = $locNode->textContent;
+            if (isset($existing[$loc])) {
+                $node->parentNode->removeChild($node);
+                continue;
+            }
+            $existing[$loc] = true;
+        }
+    }
+
+    $lastMod = date('c');
+    $added = 0;
+    foreach (array_unique($urls) as $loc) {
+        if (!isset($existing[$loc])) {
+            $urlEl = $doc->createElementNS($namespace, 'url');
+            $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
+            $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
+            $doc->documentElement->appendChild($urlEl);
+            $existing[$loc] = true;
+            $added++;
+        }
+    }
+
+    $doc->save($sitemapPath);
+    return $added;
+}
+?>

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -1,153 +1,73 @@
 <?php
-// Simple sitemap generator for sex55.net
-
+require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 require_once __DIR__ . '/includes/config.php';
+require __DIR__ . '/includes/arr_prov_nl.php';
+require __DIR__ . '/includes/arr_prov_be.php';
+require __DIR__ . '/includes/arr_prov_uk.php';
+require __DIR__ . '/includes/arr_prov_de.php';
+require __DIR__ . '/includes/arr_prov_at.php';
+require __DIR__ . '/includes/arr_prov_ch.php';
+require __DIR__ . '/includes/array_tips.php';
 
 $baseUrl = $BASE_URL;
 
-// Determine the prefix used for profile pages based on domain
 $profilePrefix = 'date-';
 if (strpos($baseUrl, 'shemaledaten.net') !== false) {
     $profilePrefix = 'shemale-';
 }
 
-/**
- * Fetch profile slugs from the remote API.
- * Expects JSON {"slugs": ["foo", "bar", ...]}
- *
- * @param string $country Two letter code
- * @return array
- */
-function fetch_profile_slugs($country)
-{
-    $endpoint = rtrim(api_base($country), '/') . '/profile/slugs';
-    $json = @file_get_contents($endpoint);
-    if ($json === false) {
-        return [];
-    }
-    $data = json_decode($json, true);
-    if (!$data || !isset($data['slugs']) || !is_array($data['slugs'])) {
-        return [];
-    }
-    return $data['slugs'];
+$urls = [];
+$static = ['', 'datingtips', 'partnerlinks', 'privacy', 'cookie-policy'];
+foreach ($static as $page) {
+    $urls[] = rtrim($baseUrl, '/') . '/' . ltrim($page, '/');
 }
 
-function add_url(array &$urls, $loc)
-{
-    $urls[] = [
-        'loc' => $loc,
-        'lastmod' => gmdate('c'),
-    ];
-}
+$countryMap = [
+    'nl' => ['slug' => 'sexdate-nederland',       'prov' => $nl],
+    'be' => ['slug' => 'sexdate-belgie',          'prov' => $be],
+    'uk' => ['slug' => 'sexdate-verenigd-koninkrijk', 'prov' => $uk],
+    'de' => ['slug' => 'sexdate-duitsland',       'prov' => $de],
+    'at' => ['slug' => 'sexdate-oostenrijk',      'prov' => $at],
+    'ch' => ['slug' => 'sexdate-zwitserland',     'prov' => $ch],
+];
 
-/**
- * Merge generated URLs into the existing sitemap without duplicating entries.
- *
- * @param array  $urls       Array with loc and lastmod keys
- * @param string $sitemap    Path to sitemap.xml
- */
-function merge_into_sitemap(array $urls, $sitemap, $baseUrl)
-{
-    $ordered = [];
-    $seen = [];
-
-    if (file_exists($sitemap)) {
-        $existingDom = new DOMDocument();
-        $existingDom->load($sitemap);
-        foreach ($existingDom->getElementsByTagName('url') as $urlNode) {
-            $locNode = $urlNode->getElementsByTagName('loc')->item(0);
-            if (!$locNode) {
-                continue;
-            }
-            $loc = trim($locNode->textContent);
-            if (isset($seen[$loc])) {
-                continue;
-            }
-            $lastmodNode = $urlNode->getElementsByTagName('lastmod')->item(0);
-            $ordered[] = [
-                'loc' => $loc,
-                'lastmod' => $lastmodNode ? $lastmodNode->textContent : gmdate('c'),
-            ];
-            $seen[$loc] = true;
+$profileUrls = [];
+foreach ($countryMap as $code => $info) {
+    $urls[] = $baseUrl . '/' . $info['slug'];
+    foreach ($info['prov'] as $slug => $prov) {
+        $provSlug = 'sexdate-' . $slug;
+        if (($code === 'nl' || $code === 'be') && $slug === 'limburg') {
+            $provSlug = 'sexdate-limburg-' . $code;
         }
-    }
+        $urls[] = $baseUrl . '/' . $provSlug;
 
-    foreach ($urls as $u) {
-        $locVal = rtrim($baseUrl, '/') . '/' . ltrim($u['loc'], '/');
-        if (isset($seen[$locVal])) {
+        $endpoint = rtrim(api_base($code), '/') . '/profile/province/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) {
             continue;
         }
-        $ordered[] = [
-            'loc' => $locVal,
-            'lastmod' => $u['lastmod'],
-        ];
-        $seen[$locVal] = true;
-    }
-
-    $dom = new DOMDocument('1.0', 'UTF-8');
-    $dom->formatOutput = true;
-    $urlset = $dom->createElement('urlset');
-    $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-    $dom->appendChild($urlset);
-
-    foreach ($ordered as $entry) {
-        $url = $dom->createElement('url');
-        $url->appendChild($dom->createElement('loc', $entry['loc']));
-        $url->appendChild($dom->createElement('lastmod', $entry['lastmod']));
-        $urlset->appendChild($url);
-    }
-
-    $dom->save($sitemap);
-}
-
-$urls = [];
-
-add_url($urls, '');
-
-$countries = [
-    'nl' => ['file' => 'includes/arr_prov_nl.php', 'var' => 'nl', 'slug' => 'sexdate-nederland'],
-    'be' => ['file' => 'includes/arr_prov_be.php', 'var' => 'be', 'slug' => 'sexdate-belgie'],
-    'uk' => ['file' => 'includes/arr_prov_uk.php', 'var' => 'uk', 'slug' => 'sexdate-verenigd-koninkrijk'],
-    'de' => ['file' => 'includes/arr_prov_de.php', 'var' => 'de', 'slug' => 'sexdate-duitsland'],
-    'at' => ['file' => 'includes/arr_prov_at.php', 'var' => 'at', 'slug' => 'sexdate-oostenrijk'],
-    'ch' => ['file' => 'includes/arr_prov_ch.php', 'var' => 'ch', 'slug' => 'sexdate-zwitserland'],
-];
-
-foreach ($countries as $country => $info) {
-    add_url($urls, $info['slug']);
-    require __DIR__ . '/' . $info['file'];
-    $provArray = ${$info['var']};
-    foreach ($provArray as $slugKey => $item) {
-        $slug = 'sexdate-' . $slugKey;
-        if (($country === 'nl' || $country === 'be') && $slugKey === 'limburg') {
-            $slug = 'sexdate-limburg-' . $country;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles']) || !is_array($data['profiles'])) {
+            continue;
         }
-        add_url($urls, $slug);
+        foreach ($data['profiles'] as $p) {
+            if (empty($p['id']) || empty($p['name'])) {
+                continue;
+            }
+            $slugified = slugify($p['name']);
+            $profileUrls[$p['id']] = $baseUrl . '/' . $profilePrefix . $slugified . '?id=' . $p['id'];
+        }
     }
-
-    foreach (fetch_profile_slugs($country) as $profileSlug) {
-        add_url($urls, $profilePrefix . $profileSlug);
-    }
 }
 
-// Dating tips
-$datingtips = [
-    'datingtips',
-    'datingtips-nederland',
-    'datingtips-belgie',
-    'datingtips-verenigd-koninkrijk',
-    'datingtips-duitsland',
-    'datingtips-oostenrijk',
-    'datingtips-zwitserland',
-];
-foreach ($datingtips as $tip) {
-    add_url($urls, $tip);
+foreach (array_keys($datingtips) as $tip) {
+    $urls[] = $baseUrl . '/datingtips-' . $tip;
 }
 
-// Static pages
-foreach (['partnerlinks', 'privacy', 'cookie-policy'] as $page) {
-    add_url($urls, $page);
+foreach ($profileUrls as $url) {
+    $urls[] = $url;
 }
 
-merge_into_sitemap($urls, __DIR__ . '/sitemap.xml', $baseUrl);
-echo sprintf("Sitemap updated with %d URLs\n", count($urls));
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/S55/includes/sitemap.php
+++ b/S55/includes/sitemap.php
@@ -1,0 +1,50 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+
+    $doc = new DOMDocument('1.0', 'UTF-8');
+    $doc->preserveWhiteSpace = false;
+    $doc->formatOutput = true;
+
+    if (file_exists($sitemapPath)) {
+        @$doc->load($sitemapPath);
+        if (!$doc->documentElement) {
+            $doc->loadXML('<urlset xmlns="' . $namespace . '"/>');
+        }
+    } else {
+        $doc->loadXML('<urlset xmlns="' . $namespace . '"/>');
+    }
+
+    $xpath = new DOMXPath($doc);
+    $xpath->registerNamespace('sm', $namespace);
+
+    $existing = [];
+    foreach ($xpath->query('//sm:url') as $node) {
+        $locNode = $xpath->query('sm:loc', $node)->item(0);
+        if ($locNode) {
+            $loc = $locNode->textContent;
+            if (isset($existing[$loc])) {
+                $node->parentNode->removeChild($node);
+                continue;
+            }
+            $existing[$loc] = true;
+        }
+    }
+
+    $lastMod = date('c');
+    $added = 0;
+    foreach (array_unique($urls) as $loc) {
+        if (!isset($existing[$loc])) {
+            $urlEl = $doc->createElementNS($namespace, 'url');
+            $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
+            $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
+            $doc->documentElement->appendChild($urlEl);
+            $existing[$loc] = true;
+            $added++;
+        }
+    }
+
+    $doc->save($sitemapPath);
+    return $added;
+}
+?>

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -1,153 +1,73 @@
 <?php
-// Simple sitemap generator for shemaledaten.net
-
+require_once __DIR__ . '/includes/utils.php';
+require_once __DIR__ . '/includes/sitemap.php';
 require_once __DIR__ . '/includes/config.php';
+require __DIR__ . '/includes/arr_prov_nl.php';
+require __DIR__ . '/includes/arr_prov_be.php';
+require __DIR__ . '/includes/arr_prov_uk.php';
+require __DIR__ . '/includes/arr_prov_de.php';
+require __DIR__ . '/includes/arr_prov_at.php';
+require __DIR__ . '/includes/arr_prov_ch.php';
+require __DIR__ . '/includes/array_tips.php';
 
 $baseUrl = $BASE_URL;
 
-// Determine the prefix used for profile pages based on domain
 $profilePrefix = 'date-';
 if (strpos($baseUrl, 'shemaledaten.net') !== false) {
     $profilePrefix = 'shemale-';
 }
 
-/**
- * Fetch profile slugs from the remote API.
- * Expects JSON {"slugs": ["foo", "bar", ...]}
- *
- * @param string $country Two letter code
- * @return array
- */
-function fetch_profile_slugs($country)
-{
-    $endpoint = rtrim(api_base($country), '/') . '/profile/slugs';
-    $json = @file_get_contents($endpoint);
-    if ($json === false) {
-        return [];
-    }
-    $data = json_decode($json, true);
-    if (!$data || !isset($data['slugs']) || !is_array($data['slugs'])) {
-        return [];
-    }
-    return $data['slugs'];
+$urls = [];
+$static = ['', 'datingtips', 'partnerlinks', 'privacy', 'cookie-policy'];
+foreach ($static as $page) {
+    $urls[] = rtrim($baseUrl, '/') . '/' . ltrim($page, '/');
 }
 
-function add_url(array &$urls, $loc)
-{
-    $urls[] = [
-        'loc' => $loc,
-        'lastmod' => gmdate('c'),
-    ];
-}
+$countryMap = [
+    'nl' => ['slug' => 'sexdate-nederland',       'prov' => $nl],
+    'be' => ['slug' => 'sexdate-belgie',          'prov' => $be],
+    'uk' => ['slug' => 'sexdate-verenigd-koninkrijk', 'prov' => $uk],
+    'de' => ['slug' => 'sexdate-duitsland',       'prov' => $de],
+    'at' => ['slug' => 'sexdate-oostenrijk',      'prov' => $at],
+    'ch' => ['slug' => 'sexdate-zwitserland',     'prov' => $ch],
+];
 
-/**
- * Merge generated URLs into the existing sitemap without duplicating entries.
- *
- * @param array  $urls       Array with loc and lastmod keys
- * @param string $sitemap    Path to sitemap.xml
- */
-function merge_into_sitemap(array $urls, $sitemap, $baseUrl)
-{
-    $ordered = [];
-    $seen = [];
-
-    if (file_exists($sitemap)) {
-        $existingDom = new DOMDocument();
-        $existingDom->load($sitemap);
-        foreach ($existingDom->getElementsByTagName('url') as $urlNode) {
-            $locNode = $urlNode->getElementsByTagName('loc')->item(0);
-            if (!$locNode) {
-                continue;
-            }
-            $loc = trim($locNode->textContent);
-            if (isset($seen[$loc])) {
-                continue;
-            }
-            $lastmodNode = $urlNode->getElementsByTagName('lastmod')->item(0);
-            $ordered[] = [
-                'loc' => $loc,
-                'lastmod' => $lastmodNode ? $lastmodNode->textContent : gmdate('c'),
-            ];
-            $seen[$loc] = true;
+$profileUrls = [];
+foreach ($countryMap as $code => $info) {
+    $urls[] = $baseUrl . '/' . $info['slug'];
+    foreach ($info['prov'] as $slug => $prov) {
+        $provSlug = 'sexdate-' . $slug;
+        if (($code === 'nl' || $code === 'be') && $slug === 'limburg') {
+            $provSlug = 'sexdate-limburg-' . $code;
         }
-    }
+        $urls[] = $baseUrl . '/' . $provSlug;
 
-    foreach ($urls as $u) {
-        $locVal = rtrim($baseUrl, '/') . '/' . ltrim($u['loc'], '/');
-        if (isset($seen[$locVal])) {
+        $endpoint = rtrim(api_base($code), '/') . '/profile/province/' . $code . '/' . rawurlencode($prov['name']) . '/120';
+        $json = @file_get_contents($endpoint);
+        if ($json === false) {
             continue;
         }
-        $ordered[] = [
-            'loc' => $locVal,
-            'lastmod' => $u['lastmod'],
-        ];
-        $seen[$locVal] = true;
-    }
-
-    $dom = new DOMDocument('1.0', 'UTF-8');
-    $dom->formatOutput = true;
-    $urlset = $dom->createElement('urlset');
-    $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-    $dom->appendChild($urlset);
-
-    foreach ($ordered as $entry) {
-        $url = $dom->createElement('url');
-        $url->appendChild($dom->createElement('loc', $entry['loc']));
-        $url->appendChild($dom->createElement('lastmod', $entry['lastmod']));
-        $urlset->appendChild($url);
-    }
-
-    $dom->save($sitemap);
-}
-
-$urls = [];
-
-add_url($urls, '');
-
-$countries = [
-    'nl' => ['file' => 'includes/arr_prov_nl.php', 'var' => 'nl', 'slug' => 'sexdate-nederland'],
-    'be' => ['file' => 'includes/arr_prov_be.php', 'var' => 'be', 'slug' => 'sexdate-belgie'],
-    'uk' => ['file' => 'includes/arr_prov_uk.php', 'var' => 'uk', 'slug' => 'sexdate-verenigd-koninkrijk'],
-    'de' => ['file' => 'includes/arr_prov_de.php', 'var' => 'de', 'slug' => 'sexdate-duitsland'],
-    'at' => ['file' => 'includes/arr_prov_at.php', 'var' => 'at', 'slug' => 'sexdate-oostenrijk'],
-    'ch' => ['file' => 'includes/arr_prov_ch.php', 'var' => 'ch', 'slug' => 'sexdate-zwitserland'],
-];
-
-foreach ($countries as $country => $info) {
-    add_url($urls, $info['slug']);
-    require __DIR__ . '/' . $info['file'];
-    $provArray = ${$info['var']};
-    foreach ($provArray as $slugKey => $item) {
-        $slug = 'sexdate-' . $slugKey;
-        if (($country === 'nl' || $country === 'be') && $slugKey === 'limburg') {
-            $slug = 'sexdate-limburg-' . $country;
+        $data = json_decode($json, true);
+        if (!$data || !isset($data['profiles']) || !is_array($data['profiles'])) {
+            continue;
         }
-        add_url($urls, $slug);
+        foreach ($data['profiles'] as $p) {
+            if (empty($p['id']) || empty($p['name'])) {
+                continue;
+            }
+            $slugified = slugify($p['name']);
+            $profileUrls[$p['id']] = $baseUrl . '/' . $profilePrefix . $slugified . '?id=' . $p['id'];
+        }
     }
-
-    foreach (fetch_profile_slugs($country) as $profileSlug) {
-        add_url($urls, $profilePrefix . $profileSlug);
-    }
 }
 
-// Dating tips
-$datingtips = [
-    'datingtips',
-    'datingtips-nederland',
-    'datingtips-belgie',
-    'datingtips-verenigd-koninkrijk',
-    'datingtips-duitsland',
-    'datingtips-oostenrijk',
-    'datingtips-zwitserland',
-];
-foreach ($datingtips as $tip) {
-    add_url($urls, $tip);
+foreach (array_keys($datingtips) as $tip) {
+    $urls[] = $baseUrl . '/datingtips-' . $tip;
 }
 
-// Static pages
-foreach (['partnerlinks', 'privacy', 'cookie-policy'] as $page) {
-    add_url($urls, $page);
+foreach ($profileUrls as $url) {
+    $urls[] = $url;
 }
 
-merge_into_sitemap($urls, __DIR__ . '/sitemap.xml', $baseUrl);
-echo sprintf("Sitemap updated with %d URLs\n", count($urls));
+$added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
+echo "Added $added new URLs to sitemap\n";

--- a/SD/includes/sitemap.php
+++ b/SD/includes/sitemap.php
@@ -1,0 +1,50 @@
+<?php
+function merge_into_sitemap(array $urls, string $sitemapPath): int {
+    $namespace = 'http://www.sitemaps.org/schemas/sitemap/0.9';
+
+    $doc = new DOMDocument('1.0', 'UTF-8');
+    $doc->preserveWhiteSpace = false;
+    $doc->formatOutput = true;
+
+    if (file_exists($sitemapPath)) {
+        @$doc->load($sitemapPath);
+        if (!$doc->documentElement) {
+            $doc->loadXML('<urlset xmlns="' . $namespace . '"/>');
+        }
+    } else {
+        $doc->loadXML('<urlset xmlns="' . $namespace . '"/>');
+    }
+
+    $xpath = new DOMXPath($doc);
+    $xpath->registerNamespace('sm', $namespace);
+
+    $existing = [];
+    foreach ($xpath->query('//sm:url') as $node) {
+        $locNode = $xpath->query('sm:loc', $node)->item(0);
+        if ($locNode) {
+            $loc = $locNode->textContent;
+            if (isset($existing[$loc])) {
+                $node->parentNode->removeChild($node);
+                continue;
+            }
+            $existing[$loc] = true;
+        }
+    }
+
+    $lastMod = date('c');
+    $added = 0;
+    foreach (array_unique($urls) as $loc) {
+        if (!isset($existing[$loc])) {
+            $urlEl = $doc->createElementNS($namespace, 'url');
+            $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
+            $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
+            $doc->documentElement->appendChild($urlEl);
+            $existing[$loc] = true;
+            $added++;
+        }
+    }
+
+    $doc->save($sitemapPath);
+    return $added;
+}
+?>


### PR DESCRIPTION
## Summary
- add reusable `merge_into_sitemap` helper
- update sitemap generator to fetch profile pages
- support all site variants

## Testing
- `php generate_sitemap.php` (18D)
- `php generate_sitemap.php` (S55)
- `php generate_sitemap.php` (SD)


------
https://chatgpt.com/codex/tasks/task_e_6874de6d922083249646a1e71f1558a6