### PR TITLE
Fix profile page canonical and meta

### DIFF
--- a/18D/includes/header.php
+++ b/18D/includes/header.php
@@ -18,14 +18,18 @@
     'item_page_title_prefix' => 'Sexdate',
     'slug_prefix' => 'date',
     'profile_prefix' => 'date',
+    'profile_title_prefix' => 'Date',
     'missing_profile_prefix' => 'Sexdate met',
     'tips_title_prefix' => 'Sexdatingtips',
   ];
 
-  list($generatedCanonical, $generatedPageTitle, $generatedOgImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  list($generatedCanonical, $generatedPageTitle, $generatedOgImage, $generatedMetaDescription) = generate_canonical_meta($cfg, isset($province) ? $province : []);
   $canonical = isset($canonical) ? $canonical : $generatedCanonical;
   $pageTitle = isset($pageTitle) ? $pageTitle : $generatedPageTitle;
   $ogImage   = isset($ogImage) ? $ogImage : $generatedOgImage;
+  if (!isset($metaDescription) && $generatedMetaDescription) {
+    $metaDescription = $generatedMetaDescription;
+  }
 
 ?>
 

--- a/S55/includes/header.php
+++ b/S55/includes/header.php
@@ -18,14 +18,18 @@
     'item_page_title_prefix' => 'Sexdate',
     'slug_prefix' => 'sexdate',
     'profile_prefix' => 'date',
+    'profile_title_prefix' => 'Date',
     'missing_profile_prefix' => 'Sexdate met',
     'tips_title_prefix' => 'Datingtips',
   ];
 
-  list($generatedCanonical, $generatedPageTitle, $generatedOgImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  list($generatedCanonical, $generatedPageTitle, $generatedOgImage, $generatedMetaDescription) = generate_canonical_meta($cfg, isset($province) ? $province : []);
   $canonical = isset($canonical) ? $canonical : $generatedCanonical;
   $pageTitle = isset($pageTitle) ? $pageTitle : $generatedPageTitle;
   $ogImage   = isset($ogImage) ? $ogImage : $generatedOgImage;
+  if (!isset($metaDescription) && $generatedMetaDescription) {
+    $metaDescription = $generatedMetaDescription;
+  }
 
 ?>
 

--- a/S55/js/profile.js
+++ b/S55/js/profile.js
@@ -22,6 +22,13 @@ function getSlugFromPath(){
     return match ? match[1] : null;
 }
 
+function stripRefFromSearch() {
+    var params = new URLSearchParams(window.location.search);
+    params.delete('ref');
+    var s = params.toString();
+    return s ? '?' + s : '';
+}
+
 var profiel= new Vue({
     router,
     el: "#profiel",
@@ -74,7 +81,7 @@ var profiel= new Vue({
                     }
                     var slug = slugify(that.profile.name || '');
                     if(slug){
-                        var newUrl = '/date-' + slug;
+                        var newUrl = '/date-' + slug + stripRefFromSearch();
                         var link = document.querySelector('link[rel=canonical]');
                         if(link){
                             link.setAttribute('href', 'https://sex55.net' + newUrl);

--- a/SD/includes/header.php
+++ b/SD/includes/header.php
@@ -18,14 +18,18 @@
     'item_page_title_prefix' => 'Shemale',
     'slug_prefix' => 'sexdate',
     'profile_prefix' => 'shemale',
+    'profile_title_prefix' => 'Shemale',
     'missing_profile_prefix' => 'Shemale',
     'tips_title_prefix' => 'Datingtips',
   ];
 
-  list($generatedCanonical, $generatedPageTitle, $generatedOgImage) = generate_canonical_meta($cfg, isset($province) ? $province : []);
+  list($generatedCanonical, $generatedPageTitle, $generatedOgImage, $generatedMetaDescription) = generate_canonical_meta($cfg, isset($province) ? $province : []);
   $canonical = isset($canonical) ? $canonical : $generatedCanonical;
   $pageTitle = isset($pageTitle) ? $pageTitle : $generatedPageTitle;
   $ogImage   = isset($ogImage) ? $ogImage : $generatedOgImage;
+  if (!isset($metaDescription) && $generatedMetaDescription) {
+    $metaDescription = $generatedMetaDescription;
+  }
 
 ?>
 

--- a/SD/js/profile.js
+++ b/SD/js/profile.js
@@ -22,6 +22,15 @@ function getSlugFromPath(){
     return match ? match[1] : null;
 }
 
+// Remove the ref parameter from a query string and return the remaining
+// search portion (including the leading '?') or an empty string if none remain
+function stripRefFromSearch() {
+    var params = new URLSearchParams(window.location.search);
+    params.delete('ref');
+    var s = params.toString();
+    return s ? '?' + s : '';
+}
+
 var profiel= new Vue({
     router,
     el: "#profiel",
@@ -74,7 +83,7 @@ var profiel= new Vue({
                     }
                     var slug = slugify(that.profile.name || '');
                     if(slug){
-                        var newUrl = '/shemale-' + slug;
+                        var newUrl = '/shemale-' + slug + stripRefFromSearch();
                         var link = document.querySelector('link[rel=canonical]');
                         if(link){
                             link.setAttribute('href', 'https://shemaledaten.net' + newUrl);


### PR DESCRIPTION
## Summary
- expose `profile_title_prefix` for correct titles
- add support for profile meta description and slugged canonical URLs
- adjust client-side canonical updates to keep id in URL

## Testing
- `php -l 18D/includes/site.php`
- `php -l 18D/includes/header.php`
- `php -l S55/includes/site.php`
- `php -l S55/includes/header.php`
- `php -l SD/includes/site.php`
- `php -l SD/includes/header.php`


------
https://chatgpt.com/codex/tasks/task_e_687503b3f29c8324880b7a861b66fba6