### PR TITLE
Fix sitemap generation issues

### DIFF
--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -13,8 +13,10 @@ require __DIR__ . '/includes/array_tips.php';
 $baseUrl = $BASE_URL;
 
 $profilePrefix = 'date-';
+$slugPrefix = 'sexdate-';
 if (strpos($baseUrl, 'shemaledaten.net') !== false) {
     $profilePrefix = 'shemale-';
+    $slugPrefix = 'shemale-';
 }
 
 $urls = [];
@@ -24,21 +26,21 @@ foreach ($static as $page) {
 }
 
 $countryMap = [
-    'nl' => ['slug' => 'sexdate-nederland',       'prov' => $nl],
-    'be' => ['slug' => 'sexdate-belgie',          'prov' => $be],
-    'uk' => ['slug' => 'sexdate-verenigd-koninkrijk', 'prov' => $uk],
-    'de' => ['slug' => 'sexdate-duitsland',       'prov' => $de],
-    'at' => ['slug' => 'sexdate-oostenrijk',      'prov' => $at],
-    'ch' => ['slug' => 'sexdate-zwitserland',     'prov' => $ch],
+    'nl' => ['slug' => $slugPrefix . 'nederland',       'prov' => $nl],
+    'be' => ['slug' => $slugPrefix . 'belgie',          'prov' => $be],
+    'uk' => ['slug' => $slugPrefix . 'verenigd-koninkrijk', 'prov' => $uk],
+    'de' => ['slug' => $slugPrefix . 'duitsland',       'prov' => $de],
+    'at' => ['slug' => $slugPrefix . 'oostenrijk',      'prov' => $at],
+    'ch' => ['slug' => $slugPrefix . 'zwitserland',     'prov' => $ch],
 ];
 
 $profileUrls = [];
 foreach ($countryMap as $code => $info) {
     $urls[] = $baseUrl . '/' . $info['slug'];
     foreach ($info['prov'] as $slug => $prov) {
-        $provSlug = 'sexdate-' . $slug;
+        $provSlug = $slugPrefix . $slug;
         if (($code === 'nl' || $code === 'be') && $slug === 'limburg') {
-            $provSlug = 'sexdate-limburg-' . $code;
+            $provSlug = $slugPrefix . 'limburg-' . $code;
         }
         $urls[] = $baseUrl . '/' . $provSlug;
 

--- a/18D/includes/sitemap.php
+++ b/18D/includes/sitemap.php
@@ -34,14 +34,15 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $lastMod = date('c');
     $added = 0;
     foreach (array_unique($urls) as $loc) {
-        if (!isset($existing[$loc])) {
-            $urlEl = $doc->createElementNS($namespace, 'url');
-            $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
-            $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
-            $doc->documentElement->appendChild($urlEl);
-            $existing[$loc] = true;
-            $added++;
+        if ($loc === '' || isset($existing[$loc])) {
+            continue;
         }
+        $urlEl = $doc->createElementNS($namespace, 'url');
+        $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
+        $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
+        $doc->documentElement->appendChild($urlEl);
+        $existing[$loc] = true;
+        $added++;
     }
 
     $doc->save($sitemapPath);

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -13,8 +13,10 @@ require __DIR__ . '/includes/array_tips.php';
 $baseUrl = $BASE_URL;
 
 $profilePrefix = 'date-';
+$slugPrefix = 'sexdate-';
 if (strpos($baseUrl, 'shemaledaten.net') !== false) {
     $profilePrefix = 'shemale-';
+    $slugPrefix = 'shemale-';
 }
 
 $urls = [];
@@ -24,21 +26,21 @@ foreach ($static as $page) {
 }
 
 $countryMap = [
-    'nl' => ['slug' => 'sexdate-nederland',       'prov' => $nl],
-    'be' => ['slug' => 'sexdate-belgie',          'prov' => $be],
-    'uk' => ['slug' => 'sexdate-verenigd-koninkrijk', 'prov' => $uk],
-    'de' => ['slug' => 'sexdate-duitsland',       'prov' => $de],
-    'at' => ['slug' => 'sexdate-oostenrijk',      'prov' => $at],
-    'ch' => ['slug' => 'sexdate-zwitserland',     'prov' => $ch],
+    'nl' => ['slug' => $slugPrefix . 'nederland',       'prov' => $nl],
+    'be' => ['slug' => $slugPrefix . 'belgie',          'prov' => $be],
+    'uk' => ['slug' => $slugPrefix . 'verenigd-koninkrijk', 'prov' => $uk],
+    'de' => ['slug' => $slugPrefix . 'duitsland',       'prov' => $de],
+    'at' => ['slug' => $slugPrefix . 'oostenrijk',      'prov' => $at],
+    'ch' => ['slug' => $slugPrefix . 'zwitserland',     'prov' => $ch],
 ];
 
 $profileUrls = [];
 foreach ($countryMap as $code => $info) {
     $urls[] = $baseUrl . '/' . $info['slug'];
     foreach ($info['prov'] as $slug => $prov) {
-        $provSlug = 'sexdate-' . $slug;
+        $provSlug = $slugPrefix . $slug;
         if (($code === 'nl' || $code === 'be') && $slug === 'limburg') {
-            $provSlug = 'sexdate-limburg-' . $code;
+            $provSlug = $slugPrefix . 'limburg-' . $code;
         }
         $urls[] = $baseUrl . '/' . $provSlug;
 

--- a/S55/includes/sitemap.php
+++ b/S55/includes/sitemap.php
@@ -34,14 +34,15 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $lastMod = date('c');
     $added = 0;
     foreach (array_unique($urls) as $loc) {
-        if (!isset($existing[$loc])) {
-            $urlEl = $doc->createElementNS($namespace, 'url');
-            $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
-            $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
-            $doc->documentElement->appendChild($urlEl);
-            $existing[$loc] = true;
-            $added++;
+        if ($loc === '' || isset($existing[$loc])) {
+            continue;
         }
+        $urlEl = $doc->createElementNS($namespace, 'url');
+        $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
+        $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
+        $doc->documentElement->appendChild($urlEl);
+        $existing[$loc] = true;
+        $added++;
     }
 
     $doc->save($sitemapPath);

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -13,8 +13,10 @@ require __DIR__ . '/includes/array_tips.php';
 $baseUrl = $BASE_URL;
 
 $profilePrefix = 'date-';
+$slugPrefix = 'sexdate-';
 if (strpos($baseUrl, 'shemaledaten.net') !== false) {
     $profilePrefix = 'shemale-';
+    $slugPrefix = 'shemale-';
 }
 
 $urls = [];
@@ -24,21 +26,21 @@ foreach ($static as $page) {
 }
 
 $countryMap = [
-    'nl' => ['slug' => 'sexdate-nederland',       'prov' => $nl],
-    'be' => ['slug' => 'sexdate-belgie',          'prov' => $be],
-    'uk' => ['slug' => 'sexdate-verenigd-koninkrijk', 'prov' => $uk],
-    'de' => ['slug' => 'sexdate-duitsland',       'prov' => $de],
-    'at' => ['slug' => 'sexdate-oostenrijk',      'prov' => $at],
-    'ch' => ['slug' => 'sexdate-zwitserland',     'prov' => $ch],
+    'nl' => ['slug' => $slugPrefix . 'nederland',       'prov' => $nl],
+    'be' => ['slug' => $slugPrefix . 'belgie',          'prov' => $be],
+    'uk' => ['slug' => $slugPrefix . 'verenigd-koninkrijk', 'prov' => $uk],
+    'de' => ['slug' => $slugPrefix . 'duitsland',       'prov' => $de],
+    'at' => ['slug' => $slugPrefix . 'oostenrijk',      'prov' => $at],
+    'ch' => ['slug' => $slugPrefix . 'zwitserland',     'prov' => $ch],
 ];
 
 $profileUrls = [];
 foreach ($countryMap as $code => $info) {
     $urls[] = $baseUrl . '/' . $info['slug'];
     foreach ($info['prov'] as $slug => $prov) {
-        $provSlug = 'sexdate-' . $slug;
+        $provSlug = $slugPrefix . $slug;
         if (($code === 'nl' || $code === 'be') && $slug === 'limburg') {
-            $provSlug = 'sexdate-limburg-' . $code;
+            $provSlug = $slugPrefix . 'limburg-' . $code;
         }
         $urls[] = $baseUrl . '/' . $provSlug;
 

--- a/SD/includes/sitemap.php
+++ b/SD/includes/sitemap.php
@@ -34,14 +34,15 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $lastMod = date('c');
     $added = 0;
     foreach (array_unique($urls) as $loc) {
-        if (!isset($existing[$loc])) {
-            $urlEl = $doc->createElementNS($namespace, 'url');
-            $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
-            $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
-            $doc->documentElement->appendChild($urlEl);
-            $existing[$loc] = true;
-            $added++;
+        if ($loc === '' || isset($existing[$loc])) {
+            continue;
         }
+        $urlEl = $doc->createElementNS($namespace, 'url');
+        $urlEl->appendChild($doc->createElementNS($namespace, 'loc', $loc));
+        $urlEl->appendChild($doc->createElementNS($namespace, 'lastmod', $lastMod));
+        $doc->documentElement->appendChild($urlEl);
+        $existing[$loc] = true;
+        $added++;
     }
 
     $doc->save($sitemapPath);


### PR DESCRIPTION
## Summary
- make sitemap URL prefix configurable so `shemaledaten.net` uses `shemale-`
- ignore empty URLs when merging sitemaps

## Testing
- `find SD S55 18D -name '*.php' | xargs -I{} php -l {}`
- `php SD/generate_sitemap.php | head`

------
https://chatgpt.com/codex/tasks/task_e_6875f886643083249fae2b85af7d85a5