### PR TITLE
Fix generation of empty sitemap entries

### DIFF
--- a/18D/generate_sitemap.php
+++ b/18D/generate_sitemap.php
@@ -71,5 +71,9 @@ foreach ($profileUrls as $url) {
     $urls[] = $url;
 }
 
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/18D/includes/sitemap.php
+++ b/18D/includes/sitemap.php
@@ -34,7 +34,7 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $lastMod = date('c');
     $added = 0;
     foreach (array_unique($urls) as $loc) {
-        if ($loc === '' || isset($existing[$loc])) {
+        if (!is_string($loc) || trim($loc) === '' || isset($existing[$loc])) {
             continue;
         }
         $urlEl = $doc->createElementNS($namespace, 'url');

--- a/S55/generate_sitemap.php
+++ b/S55/generate_sitemap.php
@@ -71,5 +71,9 @@ foreach ($profileUrls as $url) {
     $urls[] = $url;
 }
 
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/S55/includes/sitemap.php
+++ b/S55/includes/sitemap.php
@@ -34,7 +34,7 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $lastMod = date('c');
     $added = 0;
     foreach (array_unique($urls) as $loc) {
-        if ($loc === '' || isset($existing[$loc])) {
+        if (!is_string($loc) || trim($loc) === '' || isset($existing[$loc])) {
             continue;
         }
         $urlEl = $doc->createElementNS($namespace, 'url');

--- a/SD/generate_sitemap.php
+++ b/SD/generate_sitemap.php
@@ -71,5 +71,9 @@ foreach ($profileUrls as $url) {
     $urls[] = $url;
 }
 
+$urls = array_filter($urls, static function ($u) {
+    return is_string($u) && trim($u) !== '';
+});
+
 $added = merge_into_sitemap($urls, __DIR__ . '/sitemap.xml');
 echo "Added $added new URLs to sitemap\n";

--- a/SD/includes/sitemap.php
+++ b/SD/includes/sitemap.php
@@ -34,7 +34,7 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $lastMod = date('c');
     $added = 0;
     foreach (array_unique($urls) as $loc) {
-        if ($loc === '' || isset($existing[$loc])) {
+        if (!is_string($loc) || trim($loc) === '' || isset($existing[$loc])) {
             continue;
         }
         $urlEl = $doc->createElementNS($namespace, 'url');


### PR DESCRIPTION
## Summary
- filter URL lists to discard empty or non-string entries
- skip invalid URLs when inserting into sitemap

## Testing
- `php -l 18D/generate_sitemap.php`
- `php -l S55/generate_sitemap.php`
- `php -l SD/generate_sitemap.php`
- `php -l 18D/includes/sitemap.php`
- `php -l S55/includes/sitemap.php`
- `php -l SD/includes/sitemap.php`
- `php generate_sitemap.php` within 18D, S55 and SD directories

------
https://chatgpt.com/codex/tasks/task_e_687612c07f608324b677a1e9db6429b4