### PR TITLE
Fix empty entries in sitemaps

### DIFF
--- a/18D/includes/sitemap.php
+++ b/18D/includes/sitemap.php
@@ -21,14 +21,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $existing = [];
     foreach ($xpath->query('//sm:url') as $node) {
         $locNode = $xpath->query('sm:loc', $node)->item(0);
-        if ($locNode) {
-            $loc = $locNode->textContent;
-            if (isset($existing[$loc])) {
-                $node->parentNode->removeChild($node);
-                continue;
-            }
-            $existing[$loc] = true;
+        if (!$locNode) {
+            $node->parentNode->removeChild($node);
+            continue;
         }
+
+        $loc = trim($locNode->textContent);
+        if ($loc === '') {
+            $node->parentNode->removeChild($node);
+            continue;
+        }
+
+        if (isset($existing[$loc])) {
+            $node->parentNode->removeChild($node);
+            continue;
+        }
+
+        $existing[$loc] = true;
     }
 
     $lastMod = date('c');

--- a/S55/includes/sitemap.php
+++ b/S55/includes/sitemap.php
@@ -21,14 +21,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $existing = [];
     foreach ($xpath->query('//sm:url') as $node) {
         $locNode = $xpath->query('sm:loc', $node)->item(0);
-        if ($locNode) {
-            $loc = $locNode->textContent;
-            if (isset($existing[$loc])) {
-                $node->parentNode->removeChild($node);
-                continue;
-            }
-            $existing[$loc] = true;
+        if (!$locNode) {
+            $node->parentNode->removeChild($node);
+            continue;
         }
+
+        $loc = trim($locNode->textContent);
+        if ($loc === '') {
+            $node->parentNode->removeChild($node);
+            continue;
+        }
+
+        if (isset($existing[$loc])) {
+            $node->parentNode->removeChild($node);
+            continue;
+        }
+
+        $existing[$loc] = true;
     }
 
     $lastMod = date('c');

--- a/SD/includes/sitemap.php
+++ b/SD/includes/sitemap.php
@@ -21,14 +21,23 @@ function merge_into_sitemap(array $urls, string $sitemapPath): int {
     $existing = [];
     foreach ($xpath->query('//sm:url') as $node) {
         $locNode = $xpath->query('sm:loc', $node)->item(0);
-        if ($locNode) {
-            $loc = $locNode->textContent;
-            if (isset($existing[$loc])) {
-                $node->parentNode->removeChild($node);
-                continue;
-            }
-            $existing[$loc] = true;
+        if (!$locNode) {
+            $node->parentNode->removeChild($node);
+            continue;
         }
+
+        $loc = trim($locNode->textContent);
+        if ($loc === '') {
+            $node->parentNode->removeChild($node);
+            continue;
+        }
+
+        if (isset($existing[$loc])) {
+            $node->parentNode->removeChild($node);
+            continue;
+        }
+
+        $existing[$loc] = true;
     }
 
     $lastMod = date('c');


### PR DESCRIPTION
## Summary
- avoid including `<url>` elements that have no URL text when merging sitemaps
- apply fix across all site directories

## Testing
- `php -l 18D/includes/sitemap.php`
- `php -l S55/includes/sitemap.php`
- `php -l SD/includes/sitemap.php`


------
https://chatgpt.com/codex/tasks/task_e_68762bc0793c832491683bbc956fd604